### PR TITLE
Use DISM before SFC

### DIFF
--- a/clean-win.bat
+++ b/clean-win.bat
@@ -283,6 +283,13 @@ timeout /t 1
 @REM Delete all the files in the recent files folder ~ clearing the recent files folder having some issues on windows 11 (not sure why)
 del /f /s /q "%userprofile%\recent\*.*"
 
+@REM Repair System Image (used by sfc /scannow to fix corrupted files)
+echo Repairing System Image (using Windows Update if needed)
+@REM Timeout is used to make the script wait for 1 seconds
+timeout /t 1 
+@REM Repair the System Image (using Windows Update if needed)
+dism /Online /Cleanup-Image /RestoreHealth
+
 @REM Fix all the corrupted files in the system drive
 echo Scanning all protected system files, and replacing corrupted files
 @REM Timeout is used to make the script wait for 1 seconds

--- a/src/clean-win.cpp
+++ b/src/clean-win.cpp
@@ -324,6 +324,11 @@ int main()
     cout << "All recent files removed" << endl;
     Sleep(1000);
 
+    // Repairing System Image (using Windows Update if needed)
+    system("dism /Online /Cleanup-Image /RestoreHealth");
+    cout << "Repairing System Image (using Windows Update if needed)" << endl;
+    Sleep(1000);
+
     // Scanning all protected system files, and replacing corrupted files
     system("sfc /scannow");
     cout << "Scanning all protected system files, and replacing corrupted files" << endl;


### PR DESCRIPTION
`sfc /scannow` uses under the hood the system image in order to repair corrupted, missing or broken files, but sometimes it cannot repair these files because the system image itself is broken 
DISM fixes the system image

Ask if something needs to be changed